### PR TITLE
Fix the healthcheck in the new EKS environment. 

### DIFF
--- a/OPS.md
+++ b/OPS.md
@@ -1,0 +1,57 @@
+# Deploying a new backend version
+
+Once a release is built and deployed by CircleCI, deploy it to an environment using ArgoCD.
+
+1. First, to connect to ArgoCD:
+```
+kubectl -n argocd port-forward service/argocd-server 8443:443 &
+open https://localhost:8443
+```
+2. login - credentials are in 1password, or ask someone for help
+3. pick up the new version in staging.
+  - go to https://localhost:8443/applications/pyback-staging,
+  - click the hamburger menu (3 dots, blue button), -> Details -> Parameters
+  - update the images field with the build ID as the tag, like: `operationcode/back-end:staging-846`
+  - as the new pods deploy, tail their logs to check for errors
+  - validate the staging environment (notes below)
+4. repeat those steps for the production environment
+
+# Validating the staging environment
+
+This requires a working node or docker environment.  I found docker to be easier and more reliable but that was me :shrug:
+
+When you run the front-end repo in localdev mode, it automatically connects to the staging environment.
+1. install dependencies:  `docker run -it -v ${PWD}:/src -w /src node:lts yarn`
+2. run the dev server:  `docker run -it -v ${PWD}:/src -w /src -p 127.0.0.1:3000:3000/tcp node:lts yarn dev --hostname 0.0.0.0`
+3. Connect to the dev server: `open http://localhost:3000`
+
+# Certificate management with certbot
+
+Certbot runs continously as a kube operator and refreshes certs for you.  To ensure it is working,
+check the logs of the `cert-manager` pod, like:
+```
+kubectl -n cert-manager logs -f cert-manager-dcc48bf99-skhn7
+```
+
+Current version running is v0.10.1
+
+if you need for some reason to upgrade:
+1. read the release notes for all versions between current and desired, watch for breaking changes
+2. ignore the instructions about helm and kubectly apply, one minor version at a time
+```
+kubectl apply \
+  --validate=false \
+  -f https://github.com/jetstack/cert-manager/releases/download/v0.10.1/cert-manager.yaml
+```
+
+certificates installed:
+```
+$ kubectl get Certificates --all-namespaces
+NAMESPACE               NAME                READY   SECRET              AGE
+monitoring              grafana-tls         True    grafana-tls         299d
+operationcode-staging   back-end-tls        True    back-end-tls        264d
+operationcode-staging   resources-api-tls   True    resources-api-tls   299d
+operationcode           back-end-tls        True    back-end-tls        264d
+operationcode           resources-api-tls   True    resources-api-tls   299d
+```
+

--- a/poetry.lock
+++ b/poetry.lock
@@ -226,6 +226,18 @@ requests-oauthlib = ">=0.3.0"
 
 [[package]]
 category = "main"
+description = "A Django Middleware to enable use of CIDR IP ranges in ALLOWED_HOSTS."
+name = "django-allow-cidr"
+optional = false
+python-versions = "*"
+version = "0.3.1"
+
+[package.dependencies]
+Django = ">=1.8"
+netaddr = ">=0.7.19"
+
+[[package]]
+category = "main"
 description = "Django email integration for Amazon SES, Mailgun, Mailjet, Postmark, SendGrid, SendinBlue, SparkPost and other transactional ESPs"
 name = "django-anymail"
 optional = false
@@ -678,6 +690,14 @@ name = "more-itertools"
 optional = false
 python-versions = ">=3.5"
 version = "8.2.0"
+
+[[package]]
+category = "main"
+description = "A network address manipulation library for Python"
+name = "netaddr"
+optional = false
+python-versions = "*"
+version = "0.7.19"
 
 [[package]]
 category = "main"
@@ -1176,7 +1196,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools"]
 
 [metadata]
-content-hash = "db705ca995bc426c04a4f00e1673687439f042c7581b058a99f0f2032e276bf3"
+content-hash = "ad880e105ed81a7b5a1f2dca231852823d95d2a7e8bc61c3584ada41e7cb762e"
 python-versions = "^3.7"
 
 [metadata.files]
@@ -1326,6 +1346,10 @@ django = [
 ]
 django-allauth = [
     {file = "django-allauth-0.39.1.tar.gz", hash = "sha256:4444434c2f43188e16e0a7732c3638e12787ca7e5032f69b6d30b2912f53809e"},
+]
+django-allow-cidr = [
+    {file = "django-allow-cidr-0.3.1.tar.gz", hash = "sha256:d9a3b22c14e91c26ddd010c278ddf7e2c69a5421c862a3a3cd448ae57fd833e8"},
+    {file = "django_allow_cidr-0.3.1-py2.py3-none-any.whl", hash = "sha256:e8708c0511a78b80d9b74f718ee46685a1425e6d3520143bd00c773fdca56cc7"},
 ]
 django-anymail = [
     {file = "django-anymail-6.1.0.tar.gz", hash = "sha256:947c9c5de009036771ff9c4295da1836c950fdee4d7c27441181ce1021c370a8"},
@@ -1509,6 +1533,10 @@ mccabe = [
 more-itertools = [
     {file = "more-itertools-8.2.0.tar.gz", hash = "sha256:b1ddb932186d8a6ac451e1d95844b382f55e12686d51ca0c68b6f61f2ab7a507"},
     {file = "more_itertools-8.2.0-py3-none-any.whl", hash = "sha256:5dd8bcf33e5f9513ffa06d5ad33d78f31e1931ac9a18f33d37e77a180d393a7c"},
+]
+netaddr = [
+    {file = "netaddr-0.7.19-py2.py3-none-any.whl", hash = "sha256:56b3558bd71f3f6999e4c52e349f38660e54a7a8a9943335f73dfc96883e08ca"},
+    {file = "netaddr-0.7.19.tar.gz", hash = "sha256:38aeec7cdd035081d3a4c306394b19d677623bf76fa0913f6695127c7753aefd"},
 ]
 oauthlib = [
     {file = "oauthlib-3.1.0-py2.py3-none-any.whl", hash = "sha256:df884cd6cbe20e32633f1db1072e9356f53638e4361bef4e8b03c9127c9328ea"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ requests = "^2.21"
 sentry-sdk = "^0.10.1"
 six = "^1.12"
 honeycomb-beeline = "^2.11.4"
+django-allow-cidr = "^0.3.1"
 
 [tool.poetry.dev-dependencies]
 bandit = "^1.6"

--- a/src/settings/environments/production.py
+++ b/src/settings/environments/production.py
@@ -10,13 +10,9 @@ if config("EXTRA_HOSTS", default=""):
     ALLOWED_HOSTS += [s.strip() for s in os.environ["EXTRA_HOSTS"].split(",")]
 
 # Needed for AWS health check
-try:
-    import socket
-
-    local_ip = str(socket.gethostbyname(socket.gethostname()))
-    ALLOWED_HOSTS.append(local_ip)
-except Exception as ex:  # pragma: no cover
-    print(ex)
+if "allow_cidr.middleware.AllowCIDRMiddleware" not in MIDDLEWARE:  # noqa: F821
+    MIDDLEWARE += ("allow_cidr.middleware.AllowCIDRMiddleware",)  # noqa: F821
+ALLOWED_CIDR_NETS = ["192.168.0.0/16", "10.0.0.0/8", "172.16.0.0/12", "100.64.0.0/10"]
 
 DATABASES = {
     "default": {

--- a/src/settings/environments/staging.py
+++ b/src/settings/environments/staging.py
@@ -10,13 +10,9 @@ if config("EXTRA_HOSTS", default=""):
     ALLOWED_HOSTS += [s.strip() for s in os.environ["EXTRA_HOSTS"].split(",")]
 
 # Needed for AWS health check
-try:
-    import socket
-
-    local_ip = str(socket.gethostbyname(socket.gethostname()))
-    ALLOWED_HOSTS.append(local_ip)
-except Exception as ex:  # pragma: no cover
-    print(ex)
+if "allow_cidr.middleware.AllowCIDRMiddleware" not in MIDDLEWARE:  # noqa: F821
+    MIDDLEWARE += ("allow_cidr.middleware.AllowCIDRMiddleware",)  # noqa: F821
+ALLOWED_CIDR_NETS = ["192.168.0.0/16", "10.0.0.0/8", "172.16.0.0/12", "100.64.0.0/10"]
 
 DATABASES = {
     "default": {


### PR DESCRIPTION
Signed-off-by: Irving Popovetsky <irving@popovetsky.com>

# Description of changes
<!-- What does this PR change and why -->
use the django-allow-cidr plugin allow RFC1918 address spaces plus the range used in the kops cluster.  Background: https://mozilla.github.io/meao/2018/02/27/django-k8s-elb-health-checks/

bonus prize: commit some of the OPS things I've learned about this service to an `OPS.md` file

# Issue Resolved
<!-- Keeping the format 'Fixes #{ISSUE_NUMBER}' will automatically close the issue when this PR is merged -->

## Screenshots/GIFs
<!-- Please provide a view into the feature/bugfix if possible-->
