### PR TITLE
Add view for Pybot to hit for surveys

### DIFF
--- a/src/frontend/static/css/common.css
+++ b/src/frontend/static/css/common.css
@@ -28,3 +28,7 @@ footer {
     width: 100%;
     text-align: center;
 }
+
+#survey {
+    margin: 40px;
+}

--- a/src/frontend/templates/frontend/survey.html
+++ b/src/frontend/templates/frontend/survey.html
@@ -1,0 +1,6 @@
+{% extends 'frontend/base.html' %}
+{% block content %}
+<div id="survey">
+    <h3><a href="{{ link }}" target="_blank">This is your unique survey link! This can only be used once. We appreciate you taking the time to fill out our survey.</a></h3>
+</div>
+{% endblock %}

--- a/src/frontend/urls.py
+++ b/src/frontend/urls.py
@@ -7,4 +7,5 @@ urlpatterns = [
     path(
         "forms/codeschool", views.CodeschoolFormView.as_view(), name="codeschool_form"
     ),
+    path("survey", views.SurveyView.as_view(), name="survey_view"),
 ]

--- a/src/frontend/views.py
+++ b/src/frontend/views.py
@@ -15,6 +15,7 @@ logger = logging.getLogger(__name__)
 
 class IndexView(TemplateView):
     template_name = "frontend/index.html"
+    link = ""  # placeholder for unique link
 
 
 class CodeschoolFormView(FormView):
@@ -61,3 +62,7 @@ def handle_submission(form: dict) -> None:
     params = {"title": f"New Code School Request: {form['name']}", "body": body}
     res = requests.post(url, headers=headers, data=json.dumps(params))
     logger.info(f"response from github API call {res}")
+
+
+class SurveyView(TemplateView):
+    template_name = "frontend/survey.html"


### PR DESCRIPTION
# Description of changes
Add a view for the Pybot /survey command to hit. This view will be able to display the URL to a users unique one time survey. 

# Issue Resolved
Fixes #347 

## Screenshots/GIFs
<!-- Please provide a view into the feature/bugfix if possible-->
<img width="1787" alt="Screen Shot 2020-10-01 at 2 54 23 PM" src="https://user-images.githubusercontent.com/24487628/94851461-7aae1800-03f6-11eb-84cf-7107d79ff658.png">
