### PR TITLE
Only send slack invite after user verifies email

### DIFF
--- a/src/core/handlers.py
+++ b/src/core/handlers.py
@@ -64,5 +64,5 @@ def email_confirmed_callback(email_address: EmailConfirmation, **kwargs: dict) -
     add the user to the mailing list and send the slack invite
     """
     logger.info(f"Received email_confirmed signal for {email_address.email}")
-    send_slack_invite_job(user.email)
+    send_slack_invite_job(email_address.email)
     add_user_to_mailing_list(email_address.email)

--- a/src/core/handlers.py
+++ b/src/core/handlers.py
@@ -51,10 +51,9 @@ def get_username_from_jwt(payload: dict) -> str:
 def registration_callback(user: User, **kwargs: dict) -> None:
     """
     Listens for the `user_signed_up` signal and adds a background tasks to
-    send the welcome email and slack invite
+    send the welcome email
     """
     logger.info(f"Received user_signed_up signal for {user}")
-    send_slack_invite_job(user.email)
     send_welcome_email(user.email)
 
 
@@ -62,7 +61,8 @@ def registration_callback(user: User, **kwargs: dict) -> None:
 def email_confirmed_callback(email_address: EmailConfirmation, **kwargs: dict) -> None:
     """
     Listens for the `email_confirmed` signal and adds a background task to
-    add the user to the mailing list
+    add the user to the mailing list and send the slack invite
     """
     logger.info(f"Received email_confirmed signal for {email_address.email}")
+    send_slack_invite_job(user.email)
     add_user_to_mailing_list(email_address.email)

--- a/src/tests/integration/test_rest_registration.py
+++ b/src/tests/integration/test_rest_registration.py
@@ -155,9 +155,7 @@ def test_slack_invite_task_created(
     res = client.post(reverse("rest_verify_email"), {"key": groups["key"]})
 
     assert res.status_code == 200
-    tasks = BackgroundTask.objects.filter(
-        task_name="core.tasks.send_slack_invite_job"
-    )
+    tasks = BackgroundTask.objects.filter(task_name="core.tasks.send_slack_invite_job")
 
     assert len(tasks) == 1
     assert any(


### PR DESCRIPTION
# Description of changes
Before the slack invites were sent when the user registers their email, but now will be sent after the email is verified. This ensures only users with valid email addresses (and not parked or fake accounts) get invited to slack.

# Issue Resolved
Fixes #359
